### PR TITLE
Fix trove classifier for Django 1.10 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Framework :: Django :: 1.8",
         "Framework :: Django :: 1.9",
-        "Framework :: Django :: 1.9",
+        "Framework :: Django :: 1.10",
         "Environment :: Web Environment",
         "Framework :: Django",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The classifier for Django 1.9 was duplicated.

BTW, there's already 2.2.1 on PyPI, but no such version here on Github. Did you by any chance forget to push changes?