### PR TITLE
Add Django 2.2 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - DJANGO_VERSION=1.11
     - DJANGO_VERSION=2.0
     - DJANGO_VERSION=2.1
+    - DJANGO_VERSION=2.2
 install:
   - pip install 'coverage<4' # coverage>=4 has issues with python3
   - pip install -q Django==$DJANGO_VERSION coveralls
@@ -22,5 +23,9 @@ matrix:
       env: DJANGO_VERSION=2.0
     - python: "2.7"
       env: DJANGO_VERSION=2.1
+    - python: "2.7"
+      env: DJANGO_VERSION=2.2
     - python: "3.4"
       env: DJANGO_VERSION=2.1
+    - python: "3.4"
+      env: DJANGO_VERSION=2.2


### PR DESCRIPTION
This is my first PR to an open source repo, and first time using Travis, so apologies for any idiosyncrasies here. 

My company uses `dj-pagination` in our codebase and we are currently upgrading to Django 2.2.  We'd like to see if the current implementation of `dj-pagination` is compatible with Django 2.2 as is or if it will need to be updated.  I haven't run tests locally; hoping the PR will reveal any breakages or conversely indicate likely compatibility.